### PR TITLE
adding pyxis host lookup

### DIFF
--- a/internal/config/config_suit_test.go
+++ b/internal/config/config_suit_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/internal/config/pyxis.go
+++ b/internal/config/pyxis.go
@@ -1,0 +1,19 @@
+package config
+
+func PyxisHostLookup(pyxisEnv, hostOverride string) string {
+	envs := map[string]string{
+		"prod":  "catalog.redhat.com/api/containers",
+		"uat":   "catalog.uat.redhat.com/api/containers",
+		"qa":    "catalog.qa.redhat.com/api/containers",
+		"stage": "catalog.stage.redhat.com/api/containers",
+	}
+	if hostOverride != "" {
+		return hostOverride
+	}
+
+	pyxisHost, ok := envs[pyxisEnv]
+	if !ok {
+		pyxisHost = envs["prod"]
+	}
+	return pyxisHost
+}

--- a/internal/config/pyxis_test.go
+++ b/internal/config/pyxis_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Pyxis Host Lookup", func() {
+	When("Resolving the pyxis host", func() {
+		Context("having no host override", func() {
+			It("should return the default value for the requested environment", func() {
+				val := PyxisHostLookup("prod", "")
+				Expect(val).To(Equal("catalog.redhat.com/api/containers"))
+			})
+			Context("having an invalid environment value", func() {
+				It("sholud return the prod endpoint", func() {
+					val := PyxisHostLookup("invalid", "")
+					Expect(val).To(Equal("catalog.redhat.com/api/containers"))
+				})
+			})
+		})
+
+		Context("with a host override", func() {
+			It("should return the override", func() {
+				val := PyxisHostLookup("prod", "overridden")
+				Expect(val).To(Equal("overridden"))
+			})
+		})
+	})
+})

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -37,7 +37,7 @@ func BindFlagPyxisEnv(f *pflag.FlagSet) {
 }
 
 func BindFlagPyxisHost(f *pflag.FlagSet) {
-	f.String(KeyPyxisHost, defaults.DefaultPyxisHost, fmt.Sprintf("Host to use for Pyxis submissions. This will override Pyxis Env. Only set this if you know what you are doing.\n"+
+	f.String(KeyPyxisHost, "", fmt.Sprintf("Host to use for Pyxis submissions. This will override Pyxis Env. Only set this if you know what you are doing.\n"+
 		"If you do set it, it should include just the host, and the URI path. (env: PFLT_PYXIS_HOST)"))
 }
 


### PR DESCRIPTION
- adding host lookup for backwards compatibility with `preflight`
- setting host to `""` in flags since this is an override and we shouldn't take the default, otherwise host lookup does not work
- changing lookup criteria for `hasPyxisData`

**note: not sure if this is everything we need, but it's good enough to hit the submit code**